### PR TITLE
Redirect on non configured url locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Spring components with optional auto-configuration that enables resolving a **locale** (e.g. _en-GB_) for a request based on a two character **URL locale** (e.g. _gb_) at the start of the HTTP request path.
 
 For example, given mapping configuration from url locale _gb_ to locale _en-GB_, a request to `https://youdomain.com/gb/some-path` would resolve the locale as _en-GB_.
-Paths matching the URL locale pattern but without locale mappings will result in a 404.
+Paths matching the URL locale pattern but without a locale mapping configured will result in either a redirect to the fallback url locale if one has been configured, otherwise a 404.
 
 ## Installation
 
@@ -76,7 +76,9 @@ You'll need to configure the url-locale mapping. In your `application.yml`
 
 ```yaml
 url-locale:
-  fallback: en-gb
+  fallback: 
+    value: gb
+    redirectStatusCode: 301
   mapping:
     br: pt-BR
     de: de-DE
@@ -86,5 +88,5 @@ url-locale:
     us: en-US
 ```
 
-* The `fallback` is the default locale it would be inferred when there is no mapping present in the URL.
-* The `mapping` is the url locale to locale mappings you want to offer in your app. 
+* `fallback` affects the behaviour given a request to a URL locale that does not have a mapping. Specifying this configuration results in a redirect to the given url locale. A fallback locale is also inferred from this, which is resolved when no url locale is identified in the request url.
+* `mapping` is the url locale to locale mappings you want to offer in your app. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # URL Locale [![CircleCI](https://circleci.com/gh/transferwise/url-locale/tree/master.svg?style=shield)](https://circleci.com/gh/transferwise/url-locale/tree/master) [![GitHub release](https://jitpack.io/v/transferwise/url-locale.svg)](https://github.com/transferwise/url-locale/releases/latest)
 
-URL locale servlet filters and auto-configuration to setup your application locale through the URL.
+Spring components with optional auto-configuration that enables resolving a **locale** (e.g. _en-GB_) for a request based on a two character **URL locale** (e.g. _gb_) at the start of the HTTP request path.
+
+For example, given mapping configuration from url locale _gb_ to locale _en-GB_, a request to `https://youdomain.com/gb/some-path` would resolve the locale as _en-GB_.
+Paths matching the URL locale pattern but without locale mappings will result in a 404.
 
 ## Installation
 
@@ -30,27 +33,27 @@ The package includes all the necessary auto-wiring for Spring Boot, so there is 
 
 ### Available locales
 
-You can inject the locale mapping in any service or controller you might need it.
+You can inject the url locale to locale mapping in any service or controller you might need it.
 
 ```java
 @Autowired
-private Map<String, Locale> localeMapping;
+private Map<String, Locale> urlLocaleToLocaleMapping;
 ```
 
 ### Available request parameters
 
-You also have the locale and the locale mapping available in requests.
+You also have the url locale available as a request parameter.
 
 #### Spring controllers
 
 
 ```java
 @Controller
-@RequestMapping("/{locale:[a-z]{2}}")
+@RequestMapping("/{urlLocale:[a-z]{2}}")
 class MyController {
     @GetMapping("/do-something")
-    public String doSomething(@RequestAttribute("urlLocaleMapping") String urlLocaleMapping) {
-        if (urlLocaleMapping.equals("gb")) {
+    public String doSomething(@RequestAttribute("urlLocale") String urlLocale) {
+        if (urlLocale.equals("gb")) {
             return doSomethingForUK();
         }
         
@@ -62,7 +65,7 @@ class MyController {
 #### Thymeleaf templates
 
 ```html
-<div th:if="${locale == 'gb'}">
+<div th:if="${urlLocale == 'gb'}">
     Some stuff for UK 
 </div>
 ```
@@ -84,4 +87,4 @@ url-locale:
 ```
 
 * The `fallback` is the default locale it would be inferred when there is no mapping present in the URL.
-* The `mapping` is a key-value configuration for the locale mappings you'll want to offer in your app. 
+* The `mapping` is the url locale to locale mappings you want to offer in your app. 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '3.1.0'
+    version = '4.0.0'
 }
 
 subprojects {

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
@@ -16,13 +16,14 @@ import java.util.regex.Pattern;
 import static javax.servlet.http.HttpServletResponse.*;
 
 public class UrlLocaleExtractorFilter implements Filter {
-    static final String LOCALE_ATTRIBUTE = "locale";
-    private static final Pattern URL_PATTERN = Pattern.compile("^/([a-z]{2})/.*$");
 
-    private Set<String> allowedLocaleMappings;
+    static final String URL_LOCALE_ATTRIBUTE = "urlLocale";
+    private static final Pattern PATH_PATTERN = Pattern.compile("^/([a-z]{2})/.*$");
 
-    public UrlLocaleExtractorFilter(Set<String> allowedLocaleMappings) {
-        this.allowedLocaleMappings = allowedLocaleMappings;
+    private Set<String> supportedUrlLocales;
+
+    public UrlLocaleExtractorFilter(Set<String> supportedUrlLocales) {
+        this.supportedUrlLocales = supportedUrlLocales;
     }
 
     @Override
@@ -37,15 +38,15 @@ public class UrlLocaleExtractorFilter implements Filter {
     ) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
 
-        Matcher matcher = URL_PATTERN.matcher(req.getServletPath());
+        Matcher matcher = PATH_PATTERN.matcher(req.getServletPath());
         if (matcher.matches()) {
             String mapping = matcher.group(1);
-            if (!allowedLocaleMappings.contains(mapping)) {
+            if (!supportedUrlLocales.contains(mapping)) {
                 ((HttpServletResponse) response).sendError(SC_NOT_FOUND);
                 return;
             }
 
-            request.setAttribute(LOCALE_ATTRIBUTE, mapping);
+            request.setAttribute(URL_LOCALE_ATTRIBUTE, mapping);
         }
 
         chain.doFilter(request, response);

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
@@ -1,11 +1,6 @@
 package com.transferwise.urllocale;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -13,17 +8,30 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static javax.servlet.http.HttpServletResponse.*;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 public class UrlLocaleExtractorFilter implements Filter {
 
+    static final int DEFAULT_FALLBACK_STATUS_CODE = 301;
     static final String URL_LOCALE_ATTRIBUTE = "urlLocale";
     private static final Pattern PATH_PATTERN = Pattern.compile("^/([a-z]{2})/.*$");
 
     private Set<String> supportedUrlLocales;
+    private String fallback;
+    private int fallbackStatusCode;
 
     public UrlLocaleExtractorFilter(Set<String> supportedUrlLocales) {
+        this(supportedUrlLocales, null);
+    }
+
+    public UrlLocaleExtractorFilter(Set<String> supportedUrlLocales, String fallback) {
+        this(supportedUrlLocales, fallback, DEFAULT_FALLBACK_STATUS_CODE);
+    }
+
+    public UrlLocaleExtractorFilter(Set<String> supportedUrlLocales, String fallback, int fallbackStatusCode) {
         this.supportedUrlLocales = supportedUrlLocales;
+        this.fallback = fallback;
+        this.fallbackStatusCode = fallbackStatusCode;
     }
 
     @Override
@@ -32,24 +40,40 @@ public class UrlLocaleExtractorFilter implements Filter {
 
     @Override
     public void doFilter(
-        ServletRequest request,
-        ServletResponse response,
-        FilterChain chain
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain
     ) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
 
         Matcher matcher = PATH_PATTERN.matcher(req.getServletPath());
         if (matcher.matches()) {
-            String mapping = matcher.group(1);
-            if (!supportedUrlLocales.contains(mapping)) {
-                ((HttpServletResponse) response).sendError(SC_NOT_FOUND);
-                return;
+            String urlLocale = matcher.group(1);
+            if (!supportedUrlLocales.contains(urlLocale)) {
+                HttpServletResponse res = (HttpServletResponse) response;
+                if (fallback != null) {
+                    String redirectUrl = generateRedirectUrl(req.getServletPath(), req.getQueryString(), matcher.start(1), matcher.end(1));
+                    res.setStatus(fallbackStatusCode);
+                    res.setHeader("Location", redirectUrl);
+                    return;
+                } else {
+                    res.sendError(SC_NOT_FOUND);
+                    return;
+                }
             }
 
-            request.setAttribute(URL_LOCALE_ATTRIBUTE, mapping);
+            request.setAttribute(URL_LOCALE_ATTRIBUTE, urlLocale);
         }
 
         chain.doFilter(request, response);
+    }
+
+    private String generateRedirectUrl(String requestPath, String queryString, int urlLocaleStartIndex, int urlLocaleEndIndex) {
+        String redirectUrl = requestPath.substring(0, urlLocaleStartIndex) + fallback + requestPath.substring(urlLocaleEndIndex);
+        if (queryString != null) {
+            return redirectUrl + "?" + queryString;
+        }
+        return redirectUrl;
     }
 
     @Override

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -13,6 +13,10 @@ public class UrlLocaleResolver implements LocaleResolver {
     private final Map<String, Locale> urlLocaleToLocaleMapping;
     private final Locale fallback;
 
+    public UrlLocaleResolver(Map<String, Locale> urlLocaleToLocaleMapping) {
+        this(urlLocaleToLocaleMapping, null);
+    }
+
     public UrlLocaleResolver(Map<String, Locale> urlLocaleToLocaleMapping, Locale fallback) {
         this.urlLocaleToLocaleMapping = urlLocaleToLocaleMapping;
         this.fallback = fallback;

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -7,22 +7,22 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.transferwise.urllocale.UrlLocaleExtractorFilter.LOCALE_ATTRIBUTE;
+import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 
 public class UrlLocaleResolver implements LocaleResolver {
-    private final Map<String, Locale> localeMapping;
+    private final Map<String, Locale> urlLocaleToLocaleMapping;
     private final Locale fallback;
 
-    public UrlLocaleResolver(Map<String, Locale> localeMapping, Locale fallback) {
-        this.localeMapping = localeMapping;
+    public UrlLocaleResolver(Map<String, Locale> urlLocaleToLocaleMapping, Locale fallback) {
+        this.urlLocaleToLocaleMapping = urlLocaleToLocaleMapping;
         this.fallback = fallback;
     }
 
     @Override
     public Locale resolveLocale(HttpServletRequest request) {
-        String locale = (String) request.getAttribute(LOCALE_ATTRIBUTE);
+        String locale = (String) request.getAttribute(URL_LOCALE_ATTRIBUTE);
 
-        return localeMapping.getOrDefault(locale, fallback);
+        return urlLocaleToLocaleMapping.getOrDefault(locale, fallback);
     }
 
     @Override

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleExtractorFilterTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleExtractorFilterTest.java
@@ -12,7 +12,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.transferwise.urllocale.UrlLocaleExtractorFilter.LOCALE_ATTRIBUTE;
+import static com.transferwise.urllocale.UrlLocaleExtractorFilter.*;
+import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -25,14 +26,14 @@ class UrlLocaleExtractorFilterTest {
     private HttpServletResponse response;
     private FilterChain chain;
     private UrlLocaleExtractorFilter filter;
-    private Set<String> allowedLocaleMappings = new HashSet<>();
+    private Set<String> supportedUrlLocales = new HashSet<>();
 
     @BeforeEach
     void setUp() {
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
         chain = mock(FilterChain.class);
-        filter = new UrlLocaleExtractorFilter(allowedLocaleMappings);
+        filter = new UrlLocaleExtractorFilter(supportedUrlLocales);
     }
 
     @ParameterizedTest(name = "With path \"{0}\" locale should be \"{1}\"")
@@ -41,28 +42,28 @@ class UrlLocaleExtractorFilterTest {
         "/gb/, gb",
         "/es/some/path, es",
     })
-    void itShouldSetRequestLocaleAttribute(String path, String expectedLocale) {
-        whenLocaleMappingConfigured("gb");
-        whenLocaleMappingConfigured("es");
+    void itShouldSetRequestUrlLocaleAttribute(String path, String expectedUrlLocale) {
+        whenUrlLocaleMappingConfigured("gb");
+        whenUrlLocaleMappingConfigured("es");
         whenPathIs(path);
 
         doFilter();
 
-        assertLocaleAttributeEquals(expectedLocale);
+        assertUrlLocaleAttributeEquals(expectedUrlLocale);
     }
 
-    @ParameterizedTest(name = "Path \"{0}\" should not set locale attribute")
+    @ParameterizedTest(name = "Path \"{0}\" should not set urlLocale attribute")
     @CsvSource({
         "/gb",
         "/esp"
     })
-    void itShouldNotSetLocaleAttribute(String path) {
-        whenLocaleMappingConfigured("gb");
+    void itShouldNotSetUrlLocaleAttribute(String path) {
+        whenUrlLocaleMappingConfigured("gb");
         whenPathIs(path);
 
         doFilter();
 
-        assertLocaleAttributeIsNotSet();
+        assertUrlLocaleAttributeIsNotSet();
     }
 
     @ParameterizedTest
@@ -72,7 +73,7 @@ class UrlLocaleExtractorFilterTest {
         "/xx/",
         "/gb/",
     })
-    void itShouldFailToMapUnrecognisedLocale(String path) {
+    void itShouldFailToMapUnrecognisedUrlLocale(String path) {
         whenPathIs(path);
 
         doFilter();
@@ -88,8 +89,8 @@ class UrlLocaleExtractorFilterTest {
         }
     }
 
-    private void whenLocaleMappingConfigured(String mapping) {
-        allowedLocaleMappings.add(mapping);
+    private void whenUrlLocaleMappingConfigured(String mapping) {
+        supportedUrlLocales.add(mapping);
     }
 
     private void whenPathIs(String path) {
@@ -104,11 +105,11 @@ class UrlLocaleExtractorFilterTest {
         }
     }
 
-    private void assertLocaleAttributeEquals(String locale) {
-        verify(request, times(1)).setAttribute(LOCALE_ATTRIBUTE, locale);
+    private void assertUrlLocaleAttributeEquals(String urlLocale) {
+        verify(request, times(1)).setAttribute(URL_LOCALE_ATTRIBUTE, urlLocale);
     }
 
-    private void assertLocaleAttributeIsNotSet() {
+    private void assertUrlLocaleAttributeIsNotSet() {
         verify(request, times(0)).setAttribute(any(), any());
     }
 }

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.transferwise.urllocale.UrlLocaleExtractorFilter.LOCALE_ATTRIBUTE;
+import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 class UrlLocaleResolverTest {
 
     private static final Locale FALLBACK = Locale.UK;
-    private static final Map<String, Locale> LOCALE_MAPPING = new HashMap<String, Locale>() {{
+    private static final Map<String, Locale> URL_LOCALE_TO_LOCALE_MAPPING = new HashMap<String, Locale>() {{
         put("de", Locale.GERMANY);
         put("it", Locale.ITALY);
     }};
@@ -29,7 +29,7 @@ class UrlLocaleResolverTest {
 
     @BeforeEach
     void setUp() {
-        urlLocaleResolver = new UrlLocaleResolver(LOCALE_MAPPING, FALLBACK);
+        urlLocaleResolver = new UrlLocaleResolver(URL_LOCALE_TO_LOCALE_MAPPING, FALLBACK);
     }
 
     @ParameterizedTest(name = "Mapping \"{0}\" should match locale \"{1}\"")
@@ -38,15 +38,15 @@ class UrlLocaleResolverTest {
         "it, it-IT",
         ", en-GB",
     })
-    void itShouldResolveLocale(String locale, String expectedLocale) {
-        Locale resolvedLocale = urlLocaleResolver.resolveLocale(requestWithLocaleAttribute(locale));
+    void itShouldResolveLocale(String urlLocale, String expectedLocale) {
+        Locale resolvedLocale = urlLocaleResolver.resolveLocale(requestWithUrlLocaleAttribute(urlLocale));
 
         assertEquals(Locale.forLanguageTag(expectedLocale), resolvedLocale);
     }
 
-    private HttpServletRequest requestWithLocaleAttribute(String locale) {
+    private HttpServletRequest requestWithUrlLocaleAttribute(String locale) {
         HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getAttribute(LOCALE_ATTRIBUTE)).thenReturn(locale);
+        when(request.getAttribute(URL_LOCALE_ATTRIBUTE)).thenReturn(locale);
         return request;
     }
 

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
@@ -44,6 +44,17 @@ class UrlLocaleResolverTest {
         assertEquals(Locale.forLanguageTag(expectedLocale), resolvedLocale);
     }
 
+    @ParameterizedTest(name = "Mapping \"{0}\" should match locale \"{1}\"")
+    @CsvSource({
+            ", en-GB",
+    })
+    void noLocaleIsResolvedIfNoFallbackAvailable(String urlLocale) {
+        urlLocaleResolver = new UrlLocaleResolver(URL_LOCALE_TO_LOCALE_MAPPING, null);
+        Locale resolvedLocale = urlLocaleResolver.resolveLocale(requestWithUrlLocaleAttribute(urlLocale));
+
+        assertEquals(null, resolvedLocale);
+    }
+
     private HttpServletRequest requestWithUrlLocaleAttribute(String locale) {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getAttribute(URL_LOCALE_ATTRIBUTE)).thenReturn(locale);

--- a/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
+++ b/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
@@ -40,18 +40,18 @@ public class UrlLocaleAutoConfiguration {
     }
 
     @Bean
-    public Map<String, Locale> localeMapping(UrlLocaleProperties config) {
+    public Map<String, Locale> urlLocaleToLocaleMapping(UrlLocaleProperties config) {
         return config.getMapping().entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> Locale.forLanguageTag(e.getValue())));
     }
 
     @Bean
-    public LocaleResolver localeResolver(UrlLocaleProperties config, Map<String, Locale> localeMapping) {
+    public LocaleResolver localeResolver(UrlLocaleProperties config, Map<String, Locale> urlLocaleToLocaleMapping) {
         Locale fallback = Locale.forLanguageTag(config.getFallback());
-        if (!localeMapping.values().contains(fallback)) {
+        if (!urlLocaleToLocaleMapping.values().contains(fallback)) {
             throw new RuntimeException("No mapping defined for fallback \"" + config.getFallback() + "\"");
         }
-        return new UrlLocaleResolver(localeMapping, fallback);
+        return new UrlLocaleResolver(urlLocaleToLocaleMapping, fallback);
     }
 
     @Bean


### PR DESCRIPTION
This pull request contains two changes, in separate commits.
1) Firstly, an attempt to explicitly use the terms 'locale' and a 'url locale' within the code base and documentation in order to improve our common language. In two cases, the name of the bean and request attribute have changed.
2) Should a client attempt to hit the page with a non configured URL locale, this change will now redirect the client to to the fallback url locale with a redirect (with configurable code, defaulting to 301), rather than the previous behaviour of 404ing. I've denoted this as a **major change** because the usage of the `url-locale.fallback` property has changed from being a string to a complex object - and it's value from being the _locale_, to the _url locale_ in order to support the new feature.

**Rationale for 2:**
_Why do this at all?_
Not all of the TransferWise products support the same URL locale. It will give customers a better experience providing them with at least a fallback. It also should improve our SEO, by not having broken links.

_Why not do this at the proxy level?_
This is currently how we are achieving this. It has a few problems however:
- It's not cohesive, the configuration for how the application responds to requests lives in two places that need to be maintained separately.
- The team that owns the application has better control over the routing to various pages. E.g. one team won't introduce a rule that affects another application without having to make them aware.

_Why a 301 redirect?_
- To be consistent with our existing behaviour written in the Apache rules. 
- This will avoid the page appearing in Googles search results (which makes sense - as the page doesn't strictly exist). Playing devils advocate - the downside of this is that we might not begin building up our SEO presence for the page as early (even though it's in the wrong language).

_Why not a fully qualified Location header value?_
The latest version of the HTTP 1.1 specification says this is ok, and supported by all major browsers.