### PR TITLE
Separate url locale and locale concepts in the code base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # URL Locale [![CircleCI](https://circleci.com/gh/transferwise/url-locale/tree/master.svg?style=shield)](https://circleci.com/gh/transferwise/url-locale/tree/master) [![GitHub release](https://jitpack.io/v/transferwise/url-locale.svg)](https://github.com/transferwise/url-locale/releases/latest)
 
-URL locale servlet filters and auto-configuration to setup your application locale through the URL.
+Spring components with optional auto-configuration that enables resolving a **locale** (e.g. _en-GB_) for a request based on a two character **URL locale** (e.g. _gb_) at the start of the HTTP request path.
+
+For example, given mapping configuration from url locale _gb_ to locale _en-GB_, a request to `https://youdomain.com/gb/some-path` would resolve the locale as _en-GB_.
+Paths matching the URL locale pattern but without locale mappings will result in a 404.
 
 ## Installation
 
@@ -30,27 +33,27 @@ The package includes all the necessary auto-wiring for Spring Boot, so there is 
 
 ### Available locales
 
-You can inject the locale mapping in any service or controller you might need it.
+You can inject the url locale to locale mapping in any service or controller you might need it.
 
 ```java
 @Autowired
-private Map<String, Locale> localeMapping;
+private Map<String, Locale> urlLocaleToLocaleMapping;
 ```
 
-### Available request parameters
+### Available request attributes
 
-You also have the locale and the locale mapping available in requests.
+The url locale is also available as a request parameter, named `urlLocale`.
 
 #### Spring controllers
 
 
 ```java
 @Controller
-@RequestMapping("/{locale:[a-z]{2}}")
+@RequestMapping("/{urlLocale:[a-z]{2}}")
 class MyController {
     @GetMapping("/do-something")
-    public String doSomething(@RequestAttribute("urlLocaleMapping") String urlLocaleMapping) {
-        if (urlLocaleMapping.equals("gb")) {
+    public String doSomething(@RequestAttribute("urlLocale") String urlLocale) {
+        if (urlLocale.equals("gb")) {
             return doSomethingForUK();
         }
         
@@ -62,7 +65,7 @@ class MyController {
 #### Thymeleaf templates
 
 ```html
-<div th:if="${locale == 'gb'}">
+<div th:if="${urlLocale == 'gb'}">
     Some stuff for UK 
 </div>
 ```
@@ -83,5 +86,5 @@ url-locale:
     us: en-US
 ```
 
-* The `fallback` is the default locale it would be inferred when there is no mapping present in the URL.
-* The `mapping` is a key-value configuration for the locale mappings you'll want to offer in your app. 
+* The `fallback` is the default locale that will be inferred when there is no url locale found in the URL.
+* The `mapping` is the url locale to locale mappings you want to offer in your app. 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '3.1.0'
+    version = '4.0.0'
 }
 
 subprojects {

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
@@ -16,13 +16,16 @@ import java.util.regex.Pattern;
 import static javax.servlet.http.HttpServletResponse.*;
 
 public class UrlLocaleExtractorFilter implements Filter {
-    static final String LOCALE_ATTRIBUTE = "locale";
-    private static final Pattern URL_PATTERN = Pattern.compile("^/([a-z]{2})/.*$");
 
-    private Set<String> allowedLocaleMappings;
+    @Deprecated // Prefer URL_LOCALE_ATTRIBUTE. Not removing as likely to be used in templates that may not be caught in dev.
+    static final String LEGACY_LOCALE_ATTRIBUTE = "locale";
+    public static final String URL_LOCALE_ATTRIBUTE = "urlLocale";
+    private static final Pattern PATH_PATTERN = Pattern.compile("^/([a-z]{2})/.*$");
 
-    public UrlLocaleExtractorFilter(Set<String> allowedLocaleMappings) {
-        this.allowedLocaleMappings = allowedLocaleMappings;
+    private Set<String> supportedUrlLocales;
+
+    public UrlLocaleExtractorFilter(Set<String> supportedUrlLocales) {
+        this.supportedUrlLocales = supportedUrlLocales;
     }
 
     @Override
@@ -37,15 +40,16 @@ public class UrlLocaleExtractorFilter implements Filter {
     ) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
 
-        Matcher matcher = URL_PATTERN.matcher(req.getServletPath());
+        Matcher matcher = PATH_PATTERN.matcher(req.getServletPath());
         if (matcher.matches()) {
-            String mapping = matcher.group(1);
-            if (!allowedLocaleMappings.contains(mapping)) {
+            String urlLocale = matcher.group(1);
+            if (!supportedUrlLocales.contains(urlLocale)) {
                 ((HttpServletResponse) response).sendError(SC_NOT_FOUND);
                 return;
             }
 
-            request.setAttribute(LOCALE_ATTRIBUTE, mapping);
+            request.setAttribute(URL_LOCALE_ATTRIBUTE, urlLocale);
+            request.setAttribute(LEGACY_LOCALE_ATTRIBUTE, urlLocale);
         }
 
         chain.doFilter(request, response);

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -7,22 +7,22 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.transferwise.urllocale.UrlLocaleExtractorFilter.LOCALE_ATTRIBUTE;
+import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 
 public class UrlLocaleResolver implements LocaleResolver {
-    private final Map<String, Locale> localeMapping;
+    private final Map<String, Locale> urlLocaleToLocaleMapping;
     private final Locale fallback;
 
-    public UrlLocaleResolver(Map<String, Locale> localeMapping, Locale fallback) {
-        this.localeMapping = localeMapping;
+    public UrlLocaleResolver(Map<String, Locale> urlLocaleToLocaleMapping, Locale fallback) {
+        this.urlLocaleToLocaleMapping = urlLocaleToLocaleMapping;
         this.fallback = fallback;
     }
 
     @Override
     public Locale resolveLocale(HttpServletRequest request) {
-        String locale = (String) request.getAttribute(LOCALE_ATTRIBUTE);
+        String locale = (String) request.getAttribute(URL_LOCALE_ATTRIBUTE);
 
-        return localeMapping.getOrDefault(locale, fallback);
+        return urlLocaleToLocaleMapping.getOrDefault(locale, fallback);
     }
 
     @Override

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleExtractorFilterTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleExtractorFilterTest.java
@@ -12,7 +12,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.transferwise.urllocale.UrlLocaleExtractorFilter.LOCALE_ATTRIBUTE;
+import static com.transferwise.urllocale.UrlLocaleExtractorFilter.*;
+import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -25,14 +26,14 @@ class UrlLocaleExtractorFilterTest {
     private HttpServletResponse response;
     private FilterChain chain;
     private UrlLocaleExtractorFilter filter;
-    private Set<String> allowedLocaleMappings = new HashSet<>();
+    private Set<String> supportedUrlLocales = new HashSet<>();
 
     @BeforeEach
     void setUp() {
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
         chain = mock(FilterChain.class);
-        filter = new UrlLocaleExtractorFilter(allowedLocaleMappings);
+        filter = new UrlLocaleExtractorFilter(supportedUrlLocales);
     }
 
     @ParameterizedTest(name = "With path \"{0}\" locale should be \"{1}\"")
@@ -41,28 +42,28 @@ class UrlLocaleExtractorFilterTest {
         "/gb/, gb",
         "/es/some/path, es",
     })
-    void itShouldSetRequestLocaleAttribute(String path, String expectedLocale) {
-        whenLocaleMappingConfigured("gb");
-        whenLocaleMappingConfigured("es");
+    void itShouldSetRequestUrlLocaleAttribute(String path, String expectedUrlLocale) {
+        whenUrlLocaleMappingConfigured("gb");
+        whenUrlLocaleMappingConfigured("es");
         whenPathIs(path);
 
         doFilter();
 
-        assertLocaleAttributeEquals(expectedLocale);
+        assertUrlLocaleAttributeEquals(expectedUrlLocale);
     }
 
-    @ParameterizedTest(name = "Path \"{0}\" should not set locale attribute")
+    @ParameterizedTest(name = "Path \"{0}\" should not set urlLocale attribute")
     @CsvSource({
         "/gb",
         "/esp"
     })
-    void itShouldNotSetLocaleAttribute(String path) {
-        whenLocaleMappingConfigured("gb");
+    void itShouldNotSetUrlLocaleAttribute(String path) {
+        whenUrlLocaleMappingConfigured("gb");
         whenPathIs(path);
 
         doFilter();
 
-        assertLocaleAttributeIsNotSet();
+        assertUrlLocaleAttributeIsNotSet();
     }
 
     @ParameterizedTest
@@ -72,7 +73,7 @@ class UrlLocaleExtractorFilterTest {
         "/xx/",
         "/gb/",
     })
-    void itShouldFailToMapUnrecognisedLocale(String path) {
+    void itShouldFailToMapUnrecognisedUrlLocale(String path) {
         whenPathIs(path);
 
         doFilter();
@@ -88,8 +89,8 @@ class UrlLocaleExtractorFilterTest {
         }
     }
 
-    private void whenLocaleMappingConfigured(String mapping) {
-        allowedLocaleMappings.add(mapping);
+    private void whenUrlLocaleMappingConfigured(String mapping) {
+        supportedUrlLocales.add(mapping);
     }
 
     private void whenPathIs(String path) {
@@ -104,11 +105,12 @@ class UrlLocaleExtractorFilterTest {
         }
     }
 
-    private void assertLocaleAttributeEquals(String locale) {
-        verify(request, times(1)).setAttribute(LOCALE_ATTRIBUTE, locale);
+    private void assertUrlLocaleAttributeEquals(String urlLocale) {
+        verify(request, times(1)).setAttribute(URL_LOCALE_ATTRIBUTE, urlLocale);
+        verify(request, times(1)).setAttribute(LEGACY_LOCALE_ATTRIBUTE, urlLocale);
     }
 
-    private void assertLocaleAttributeIsNotSet() {
+    private void assertUrlLocaleAttributeIsNotSet() {
         verify(request, times(0)).setAttribute(any(), any());
     }
 }

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.transferwise.urllocale.UrlLocaleExtractorFilter.LOCALE_ATTRIBUTE;
+import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 class UrlLocaleResolverTest {
 
     private static final Locale FALLBACK = Locale.UK;
-    private static final Map<String, Locale> LOCALE_MAPPING = new HashMap<String, Locale>() {{
+    private static final Map<String, Locale> URL_LOCALE_TO_LOCALE_MAPPING = new HashMap<String, Locale>() {{
         put("de", Locale.GERMANY);
         put("it", Locale.ITALY);
     }};
@@ -29,7 +29,7 @@ class UrlLocaleResolverTest {
 
     @BeforeEach
     void setUp() {
-        urlLocaleResolver = new UrlLocaleResolver(LOCALE_MAPPING, FALLBACK);
+        urlLocaleResolver = new UrlLocaleResolver(URL_LOCALE_TO_LOCALE_MAPPING, FALLBACK);
     }
 
     @ParameterizedTest(name = "Mapping \"{0}\" should match locale \"{1}\"")
@@ -38,15 +38,15 @@ class UrlLocaleResolverTest {
         "it, it-IT",
         ", en-GB",
     })
-    void itShouldResolveLocale(String locale, String expectedLocale) {
-        Locale resolvedLocale = urlLocaleResolver.resolveLocale(requestWithLocaleAttribute(locale));
+    void itShouldResolveLocale(String urlLocale, String expectedLocale) {
+        Locale resolvedLocale = urlLocaleResolver.resolveLocale(requestWithUrlLocaleAttribute(urlLocale));
 
         assertEquals(Locale.forLanguageTag(expectedLocale), resolvedLocale);
     }
 
-    private HttpServletRequest requestWithLocaleAttribute(String locale) {
+    private HttpServletRequest requestWithUrlLocaleAttribute(String locale) {
         HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getAttribute(LOCALE_ATTRIBUTE)).thenReturn(locale);
+        when(request.getAttribute(URL_LOCALE_ATTRIBUTE)).thenReturn(locale);
         return request;
     }
 

--- a/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
+++ b/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
@@ -40,18 +40,18 @@ public class UrlLocaleAutoConfiguration {
     }
 
     @Bean
-    public Map<String, Locale> localeMapping(UrlLocaleProperties config) {
+    public Map<String, Locale> urlLocaleToLocaleMapping(UrlLocaleProperties config) {
         return config.getMapping().entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> Locale.forLanguageTag(e.getValue())));
     }
 
     @Bean
-    public LocaleResolver localeResolver(UrlLocaleProperties config, Map<String, Locale> localeMapping) {
+    public LocaleResolver localeResolver(UrlLocaleProperties config, Map<String, Locale> urlLocaleToLocaleMapping) {
         Locale fallback = Locale.forLanguageTag(config.getFallback());
-        if (!localeMapping.values().contains(fallback)) {
+        if (!urlLocaleToLocaleMapping.values().contains(fallback)) {
             throw new RuntimeException("No mapping defined for fallback \"" + config.getFallback() + "\"");
         }
-        return new UrlLocaleResolver(localeMapping, fallback);
+        return new UrlLocaleResolver(urlLocaleToLocaleMapping, fallback);
     }
 
     @Bean


### PR DESCRIPTION
Making the definitions of URL locale + locale a little clearer. A major change, because the name of the bean containing the mappings has changed.