### PR TITLE
Handle domains that include a port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '8.0.0'
+    version = '8.0.1'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '8.0.1'
+    version = '8.0.2'
 }
 
 subprojects {

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/hreflang/LocalisedLink.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/hreflang/LocalisedLink.java
@@ -29,20 +29,25 @@ public class LocalisedLink implements Comparable<LocalisedLink> {
             if (!resource.startsWith("/")) {
                 resource = "/" + resource;
             }
-            String[] splitForProtocol = domain.split("://");
-            String protocol = splitForProtocol[0];
-            String[] splitForHostname = splitForProtocol[1].split(":");
-            String hostname = splitForHostname[0];
-            int port = "".equals(splitForHostname[1]) ? -1 : Integer.parseInt(splitForHostname[1]);
 
-            String path = "/" + urlLocale + resource;
-            URI uri = new URI(protocol, null, hostname, port, path, queryString, null);
+            URI domainUri = new URI(domain);
+
+            if (domainUri.getScheme() == null || domainUri.getHost() == null) {
+                throw new IllegalArgumentException(String.format("Invalid Domain '%s'. Domain must include scheme and host", domain));
+            }
+
+            URI uri = new URI(
+                domainUri.getScheme(),
+                null,
+                domainUri.getHost(),
+                domainUri.getPort(),
+                "/" + urlLocale + resource,
+                queryString,
+                null
+            );
             return uri.toString();
-
         } catch (URISyntaxException exc) {
             throw new IllegalArgumentException(exc.getMessage());
-        } catch (IndexOutOfBoundsException exc) {
-            throw new IllegalArgumentException(String.format("Invalid domain: %s", domain));
         }
     }
 

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/hreflang/LocalisedLink.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/hreflang/LocalisedLink.java
@@ -29,11 +29,14 @@ public class LocalisedLink implements Comparable<LocalisedLink> {
             if (!resource.startsWith("/")) {
                 resource = "/" + resource;
             }
-            String[] split = domain.split("://");
-            String protocol = split[0];
-            String hostname = split[1];
+            String[] splitForProtocol = domain.split("://");
+            String protocol = splitForProtocol[0];
+            String[] splitForHostname = splitForProtocol[1].split(":");
+            String hostname = splitForHostname[0];
+            int port = "".equals(splitForHostname[1]) ? -1 : Integer.parseInt(splitForHostname[1]);
+
             String path = "/" + urlLocale + resource;
-            URI uri = new URI(protocol, null, hostname, -1, path, queryString, null);
+            URI uri = new URI(protocol, null, hostname, port, path, queryString, null);
             return uri.toString();
 
         } catch (URISyntaxException exc) {

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/hreflang/LocalisedLinkFactoryTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/hreflang/LocalisedLinkFactoryTest.java
@@ -24,32 +24,32 @@ class LocalisedLinkFactoryTest {
 
     @Test
     void itReturnsAnEmptyCollectionIfNoHreflangMappingsAreProvided() {
-        LocalisedLinkFactory factory = new LocalisedLinkFactory(DOMAIN, HREFLANG_CONFIG);
+        LocalisedLinkFactory factory = new LocalisedLinkFactory(HREFLANG_CONFIG);
 
         when(HREFLANG_CONFIG.getHreflangToUrlLocaleMapping()).thenReturn(Collections.emptyMap());
         when(HREFLANG_CONFIG.getxDefault()).thenReturn(null);
 
-        assertEquals(factory.linksForResource("/").size(), 0);
+        assertEquals(factory.linksForResource(DOMAIN, "/").size(), 0);
     }
 
     @Test
     void itCreatesXDefaultLink() {
-        LocalisedLinkFactory factory = new LocalisedLinkFactory(DOMAIN, HREFLANG_CONFIG);
+        LocalisedLinkFactory factory = new LocalisedLinkFactory(HREFLANG_CONFIG);
 
         when(HREFLANG_CONFIG.getHreflangToUrlLocaleMapping()).thenReturn(Collections.emptyMap());
         when(HREFLANG_CONFIG.getxDefault()).thenReturn("gb");
 
-        assertEquals(factory.linksForResource("/").size(), 1);
+        assertEquals(factory.linksForResource(DOMAIN, "/").size(), 1);
     }
 
     @Test
     void itGeneratesLinksFromHreflangToUrlLocaleMapping() {
 
-        LocalisedLinkFactory factory = new LocalisedLinkFactory(DOMAIN, HREFLANG_CONFIG);
+        LocalisedLinkFactory factory = new LocalisedLinkFactory(HREFLANG_CONFIG);
         when(HREFLANG_CONFIG.getHreflangToUrlLocaleMapping()).thenReturn(hreflangToUrlLocaleMap);
         when(HREFLANG_CONFIG.getxDefault()).thenReturn(null);
 
-        List<LocalisedLink> links = factory.linksForResource("/path");
+        List<LocalisedLink> links = factory.linksForResource(DOMAIN, "/path");
         assertEquals(links.size(), 3);
         assertEquals(links.get(0).getHreflang(), "en-GB");
         assertEquals(links.get(1).getHreflang(), "fr");

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/hreflang/LocalisedLinkTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/hreflang/LocalisedLinkTest.java
@@ -86,4 +86,10 @@ class LocalisedLinkTest {
         LocalisedLink link = new LocalisedLink(mockHreflang, "https://example.test", "gb", "/path", "a=1&b=2");
         assertEquals(link.getHref(), "https://example.test/gb/path?a=1&b=2");
     }
+
+    @Test
+    void itHandlesPorts() {
+        LocalisedLink link = new LocalisedLink(mockHreflang, "https://localhost:12345", "gb", "/path");
+        assertEquals("https://localhost:12345/gb/path", link.getHref());
+    }
 }


### PR DESCRIPTION
Useful for localhost:8080, transferwise:443, etc.

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
