### PR TITLE
Avoid collision in @Bean name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '8.0.2'
+    version = '8.1.0'
 }
 
 subprojects {

--- a/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
+++ b/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
@@ -46,9 +46,9 @@ public class UrlLocaleAutoConfiguration {
     }
 
     @Bean
-    public LocaleResolver localeResolver(UrlLocaleProperties config, Map<String, Locale> urlLocaleToLocaleMapping) {
+    public LocaleResolver urlLocaleLocaleResolver(UrlLocaleProperties config, Map<String, Locale> urlLocaleToLocaleMapping) {
         Locale fallback = Locale.forLanguageTag(config.getFallback());
-        if (!urlLocaleToLocaleMapping.values().contains(fallback)) {
+        if (!urlLocaleToLocaleMapping.containsValue(fallback)) {
             throw new RuntimeException("No mapping defined for fallback \"" + config.getFallback() + "\"");
         }
         return new UrlLocaleResolver(urlLocaleToLocaleMapping, fallback);


### PR DESCRIPTION
url-locale is often used in projects that make use of Spring's Web MVC.
WebMvcAutoConfiguration includes a @Bean with name "localeResolver" (with type
org.springframework.web.servlet.LocaleResolver). As we cannot have 2 beans with
the same name any app with both url-locale and Web MVC will fail to start.

By renaming the method the bean is defined with we rename the bean and avoid
the collision.

https://github.com/spring-projects/spring-boot/blob/1395e1eb3251ef8351fdb5eed8f92d4731cd076f/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java#L301

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
