### PR TITLE
@AutoConfigureBefore WebMvcAutoConfiguration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '8.1.0'
+    version = '8.2.0'
 }
 
 subprojects {

--- a/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
+++ b/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
@@ -50,7 +50,7 @@ public class UrlLocaleAutoConfiguration {
     }
 
     @Bean(name = DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME)
-    public LocaleResolver urlLocaleLocaleResolver(UrlLocaleProperties config, Map<String, Locale> urlLocaleToLocaleMapping) {
+    public LocaleResolver localeResolver(UrlLocaleProperties config, Map<String, Locale> urlLocaleToLocaleMapping) {
         Locale fallback = Locale.forLanguageTag(config.getFallback());
         if (!urlLocaleToLocaleMapping.containsValue(fallback)) {
             throw new RuntimeException("No mapping defined for fallback \"" + config.getFallback() + "\"");

--- a/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
+++ b/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
@@ -1,9 +1,12 @@
 package com.transferwise.urllocale;
 
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.LocaleResolver;
 
 import javax.servlet.Filter;
@@ -12,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@AutoConfigureBefore(WebMvcAutoConfiguration.class)
 @Configuration
 @EnableConfigurationProperties(UrlLocaleAutoConfiguration.UrlLocaleProperties.class)
 public class UrlLocaleAutoConfiguration {
@@ -45,7 +49,7 @@ public class UrlLocaleAutoConfiguration {
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> Locale.forLanguageTag(e.getValue())));
     }
 
-    @Bean
+    @Bean(name = DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME)
     public LocaleResolver urlLocaleLocaleResolver(UrlLocaleProperties config, Map<String, Locale> urlLocaleToLocaleMapping) {
         Locale fallback = Locale.forLanguageTag(config.getFallback());
         if (!urlLocaleToLocaleMapping.containsValue(fallback)) {


### PR DESCRIPTION
In order for our LocaleResovler to be used by Spring it must have the name
"localeResolver".

However, WebMvcAutoConfiguration includes it's own LocaleResovler. If the
WebMvc LocaleResolver is registered before our LocaleResolver the app will fail
to start due to bean name conflict.

Therefor we must ensure our auto configuration runs before the
WebMvcAutoConfiguration

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
