### PR TITLE
Add lang request param feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '8.2.0'
+    version = '8.3.0'
 }
 
 subprojects {

--- a/url-locale-core/build.gradle
+++ b/url-locale-core/build.gradle
@@ -1,16 +1,19 @@
 ext {
     junitVersion = '5.2.0'
+    springVersion = '4.3.10.RELEASE'
 }
 
 dependencies {
-    compile 'javax.servlet:javax.servlet-api:3.1.0'
-    compile 'org.springframework:spring-webmvc:4.3.10.RELEASE'
+    implementation 'javax.servlet:javax.servlet-api:3.1.0'
+    implementation "org.springframework:spring-webmvc:$springVersion"
 
-    testCompile "org.junit.jupiter:junit-jupiter-api:$junitVersion"
-    testCompile "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation "org.springframework:spring-test:$springVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+    testImplementation 'org.mockito:mockito-core:2.+'
+
     testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
-
-    testCompile 'org.mockito:mockito-core:2.+'
 }
 
 test {

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -1,32 +1,66 @@
 package com.transferwise.urllocale;
 
-import org.springframework.web.servlet.LocaleResolver;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.Locale;
-import java.util.Map;
-
 import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 
-public class UrlLocaleResolver implements LocaleResolver {
-    private final Map<String, Locale> urlLocaleToLocaleMapping;
-    private final Locale fallback;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-    public UrlLocaleResolver(Map<String, Locale> urlLocaleToLocaleMapping, Locale fallback) {
-        this.urlLocaleToLocaleMapping = urlLocaleToLocaleMapping;
+import org.springframework.web.servlet.LocaleResolver;
+
+public class UrlLocaleResolver implements LocaleResolver {
+
+    private final Locale fallback;
+    private final Map<String, Locale> urlLocaleToLocaleMapping;
+    private final boolean langParameterEnabled;
+    private final Set<String> supportedLanguages;
+
+    public UrlLocaleResolver(Map<String, Locale> urlLocaleToLocaleMapping, Locale fallback, boolean langParameterEnabled) {
         this.fallback = fallback;
+        this.urlLocaleToLocaleMapping = urlLocaleToLocaleMapping;
+        this.supportedLanguages = urlLocaleToLocaleMapping.values()
+            .stream()
+            .map(Locale::getLanguage)
+            .collect(Collectors.toSet());
+        this.langParameterEnabled = langParameterEnabled;
     }
 
     @Override
     public Locale resolveLocale(HttpServletRequest request) {
-        String locale = (String) request.getAttribute(URL_LOCALE_ATTRIBUTE);
+        String urlLocaleStr = (String) request.getAttribute(URL_LOCALE_ATTRIBUTE);
+        Locale urlLocale = urlLocaleToLocaleMapping.getOrDefault(urlLocaleStr, fallback);
 
-        return urlLocaleToLocaleMapping.getOrDefault(locale, fallback);
+        String lang = resolveLangParameter(request);
+        if (lang != null) {
+            return new Locale(lang, urlLocale.getCountry());
+        }
+
+        return urlLocale;
     }
 
     @Override
     public void setLocale(HttpServletRequest request, HttpServletResponse response, Locale locale) {
         throw new UnsupportedOperationException();
+    }
+
+    private String resolveLangParameter(HttpServletRequest request) {
+        if (!langParameterEnabled) {
+            return null;
+        }
+
+        String lang = request.getParameter("lang");
+
+        if (lang == null) {
+            return null;
+        }
+
+        if (!supportedLanguages.contains(lang.toLowerCase())) {
+            return null;
+        }
+
+        return lang;
     }
 }

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -31,14 +31,14 @@ public class UrlLocaleResolver implements LocaleResolver {
     @Override
     public Locale resolveLocale(HttpServletRequest request) {
         String urlLocaleStr = (String) request.getAttribute(URL_LOCALE_ATTRIBUTE);
-        Locale urlLocale = urlLocaleToLocaleMapping.getOrDefault(urlLocaleStr, fallback);
+        Locale locale = urlLocaleToLocaleMapping.getOrDefault(urlLocaleStr, fallback);
 
         String lang = resolveLangParameter(request);
         if (lang != null) {
-            return new Locale(lang, urlLocale.getCountry());
+            locale = new Locale(lang, locale.getCountry());
         }
 
-        return urlLocale;
+        return locale;
     }
 
     @Override

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
@@ -1,42 +1,21 @@
 package com.transferwise.urllocale;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
 import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class UrlLocaleResolverTest {
-
-    private static final Locale FALLBACK = Locale.UK;
-    private static final Map<String, Locale> URL_LOCALE_TO_LOCALE_MAPPING;
-
-    static {
-        Map<String, Locale> mappings = new HashMap<>();
-        mappings.put("de", Locale.GERMANY);
-        mappings.put("it", Locale.ITALY);
-        mappings.put("zh-hk", new Locale("zh", "HK"));
-
-        URL_LOCALE_TO_LOCALE_MAPPING = mappings;
-    };
-
-    private UrlLocaleResolver urlLocaleResolver;
-
-    @BeforeEach
-    void setUp() {
-        urlLocaleResolver = new UrlLocaleResolver(URL_LOCALE_TO_LOCALE_MAPPING, FALLBACK);
-    }
 
     @ParameterizedTest(name = "Mapping \"{0}\" should match locale \"{1}\"")
     @CsvSource({
@@ -46,22 +25,52 @@ class UrlLocaleResolverTest {
         ", en-GB",
     })
     void itShouldResolveLocale(String urlLocale, String expectedLocale) {
-        Locale resolvedLocale = urlLocaleResolver.resolveLocale(requestWithUrlLocaleAttribute(urlLocale));
+        Map<String, Locale> urlLocaleToLocaleMapping = new HashMap<>();
+        urlLocaleToLocaleMapping.put("de", Locale.GERMANY);
+        urlLocaleToLocaleMapping.put("it", Locale.ITALY);
+        urlLocaleToLocaleMapping.put("zh-hk", new Locale("zh", "HK"));
+        UrlLocaleResolver resolver = new UrlLocaleResolver(urlLocaleToLocaleMapping, Locale.UK, false);
 
-        assertEquals(Locale.forLanguageTag(expectedLocale), resolvedLocale);
+        Locale actualLocale = resolver.resolveLocale(requestWithUrlLocaleAttribute(urlLocale));
+
+        assertThat(actualLocale).isEqualTo(Locale.forLanguageTag(expectedLocale));
     }
 
     private HttpServletRequest requestWithUrlLocaleAttribute(String locale) {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getAttribute(URL_LOCALE_ATTRIBUTE)).thenReturn(locale);
-        return request;
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.setAttribute(URL_LOCALE_ATTRIBUTE, locale);
+        return mockRequest;
     }
 
     @Test
     void itShouldNotSupportLocaleChange() {
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> urlLocaleResolver.setLocale(mock(HttpServletRequest.class), mock(HttpServletResponse.class), Locale.UK)
+        UrlLocaleResolver resolver = new UrlLocaleResolver(new HashMap<>(), Locale.UK, false);
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(
+            () -> resolver.setLocale(new MockHttpServletRequest(), new MockHttpServletResponse(), Locale.UK)
         );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "de, ,   de",
+        "de, es, es",
+        "xx, ,   en",  // invalid url locale, fallback to default language
+        "de, xx, de",  // invalid lang param, fallback to url locale language
+        "de, '', de",  // empty lang param
+        "de, ,   de",  // null lang param
+    })
+    void itShouldResolveLangParameter(String urlLocale, String langParam, String expectedLanguage) {
+        Map<String, Locale> urlLocaleToLocaleMapping = new HashMap<>();
+        urlLocaleToLocaleMapping.put("de", new Locale("de", "DE"));
+        urlLocaleToLocaleMapping.put("es", new Locale("es", "ES"));
+        UrlLocaleResolver resolver = new UrlLocaleResolver(urlLocaleToLocaleMapping, Locale.UK, true);
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.setAttribute(URL_LOCALE_ATTRIBUTE, urlLocale);
+        mockRequest.setParameter("lang", langParam);
+
+        String actualLanguage = resolver.resolveLocale(mockRequest).getLanguage();
+
+        assertThat(actualLanguage).isEqualTo(expectedLanguage);
     }
 }

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
@@ -84,7 +84,7 @@ class UrlLocaleResolverTest {
     }
 
     @Test
-    void itShouldIgnoreLangParameterNotEnabled() {
+    void itShouldIgnoreLangParameterWhenNotEnabled() {
         Map<String, Locale> urlLocaleToLocaleMapping = new HashMap<>();
         urlLocaleToLocaleMapping.put("de", new Locale("de", "DE"));
         urlLocaleToLocaleMapping.put("es", new Locale("es", "ES"));

--- a/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
+++ b/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
@@ -19,12 +19,14 @@ import java.util.stream.Collectors;
 @Configuration
 @EnableConfigurationProperties(UrlLocaleAutoConfiguration.UrlLocaleProperties.class)
 public class UrlLocaleAutoConfiguration {
+
     @ConfigurationProperties(prefix = "url-locale")
     static class UrlLocaleProperties {
         private Map<String, String> mapping = new HashMap<String, String>() {{
             put("gb", "en-GB");
         }};
         private String fallback = "en-gb";
+        private boolean langParameterEnabled = false;
 
         public Map<String, String> getMapping() {
             return mapping;
@@ -41,6 +43,14 @@ public class UrlLocaleAutoConfiguration {
         public void setFallback(String fallback) {
             this.fallback = fallback;
         }
+
+        public boolean isLangParameterEnabled() {
+            return langParameterEnabled;
+        }
+
+        public void setLangParameterEnabled(boolean langParameterEnabled) {
+            this.langParameterEnabled = langParameterEnabled;
+        }
     }
 
     @Bean
@@ -55,7 +65,7 @@ public class UrlLocaleAutoConfiguration {
         if (!urlLocaleToLocaleMapping.containsValue(fallback)) {
             throw new RuntimeException("No mapping defined for fallback \"" + config.getFallback() + "\"");
         }
-        return new UrlLocaleResolver(urlLocaleToLocaleMapping, fallback);
+        return new UrlLocaleResolver(urlLocaleToLocaleMapping, fallback, config.isLangParameterEnabled());
     }
 
     @Bean


### PR DESCRIPTION
Consumers of this library  can enable the feature in their configuration using
`url-locale.lang-parameter-enabled=true`.

When enabled, if the request includes a lang parameter the url locale resolver
will attempt to use that language instead of the default language for the url
locale.

The language parameter must be an ISO 639-1 alpha 2 language code. It also must
be supported. The set of supported languages is the set of languges used by the
existing url locales. If the lang parameter does not match one of these
languages the default language for the url locale will be used.

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
