### PR TITLE
OGE-298 Add support for zh_HK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '8.3.1'
+    version = '8.3.2'
 }
 
 subprojects {

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
@@ -19,7 +19,7 @@ public class LocaleDataCookieAddingInterceptor implements HandlerInterceptor {
     private final String cookieName;
     private final int cookieMaxAge;
 
-    private final List<String> FIVE_CHARACTER_LANGUAGE = Collections.singletonList("zh_HK");
+    private final List<String> FIVE_CHARACTER_LANGUAGES = Collections.singletonList("zh_HK");
 
     public LocaleDataCookieAddingInterceptor(String cookieName, int cookieMaxAge){
         this.cookieName = cookieName;

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
@@ -17,6 +17,8 @@ public class LocaleDataCookieAddingInterceptor implements HandlerInterceptor {
     private final String cookieName;
     private final int cookieMaxAge;
 
+    private final String FIVE_CHARACTER_LANGUAGE = "zh_HK";
+
     public LocaleDataCookieAddingInterceptor(String cookieName, int cookieMaxAge){
         this.cookieName = cookieName;
         this.cookieMaxAge = cookieMaxAge;
@@ -29,12 +31,21 @@ public class LocaleDataCookieAddingInterceptor implements HandlerInterceptor {
         }
         LocaleContext localeContext = LocaleContextHolder.getLocaleContext();
         if (localeContext != null && localeContext.getLocale() != null) {
-            Cookie localeDataCookie = new Cookie(cookieName, localeContext.getLocale().toLanguageTag().replace("-", "_"));
+            String language = getLanguageFromLocaleContext(localeContext);
+            Cookie localeDataCookie = new Cookie(cookieName, language);
             localeDataCookie.setMaxAge(cookieMaxAge);
             localeDataCookie.setPath("/");
             response.addCookie(localeDataCookie);
         }
         return true;
+    }
+
+    private String getLanguageFromLocaleContext(LocaleContext localeContext) {
+        if (localeContext.getLocale().toLanguageTag().replace("-", "_").equalsIgnoreCase(FIVE_CHARACTER_LANGUAGE)) {
+            return FIVE_CHARACTER_LANGUAGE;
+        } else {
+            return localeContext.getLocale().getLanguage();
+        }
     }
 
     @Override

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
@@ -10,6 +10,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Component
 public class LocaleDataCookieAddingInterceptor implements HandlerInterceptor {
@@ -17,7 +19,7 @@ public class LocaleDataCookieAddingInterceptor implements HandlerInterceptor {
     private final String cookieName;
     private final int cookieMaxAge;
 
-    private final String FIVE_CHARACTER_LANGUAGE = "zh_HK";
+    private final List<String> FIVE_CHARACTER_LANGUAGE = Collections.singletonList("zh_HK");
 
     public LocaleDataCookieAddingInterceptor(String cookieName, int cookieMaxAge){
         this.cookieName = cookieName;
@@ -41,8 +43,9 @@ public class LocaleDataCookieAddingInterceptor implements HandlerInterceptor {
     }
 
     private String getLanguageFromLocaleContext(LocaleContext localeContext) {
-        if (localeContext.getLocale().toLanguageTag().replace("-", "_").equalsIgnoreCase(FIVE_CHARACTER_LANGUAGE)) {
-            return FIVE_CHARACTER_LANGUAGE;
+        String languageTag = localeContext.getLocale().toLanguageTag().replace("-", "_");
+        if (FIVE_CHARACTER_LANGUAGE.contains(languageTag)) {
+            return languageTag;
         } else {
             return localeContext.getLocale().getLanguage();
         }

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -2,6 +2,10 @@ package com.transferwise.urllocale;
 
 import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -18,12 +22,19 @@ public class UrlLocaleResolver implements LocaleResolver {
     private final boolean langParameterEnabled;
     private final Set<String> supportedLanguages;
 
+    private static final Map<String, String> fiveCharacterLanguages;
+
+    static {
+        fiveCharacterLanguages  = new HashMap<>();
+        fiveCharacterLanguages.put("hk", "zh_HK");
+    }
+
     public UrlLocaleResolver(Map<String, Locale> urlLocaleToLocaleMapping, Locale fallback, boolean langParameterEnabled) {
         this.fallback = fallback;
         this.urlLocaleToLocaleMapping = urlLocaleToLocaleMapping;
         this.supportedLanguages = urlLocaleToLocaleMapping.values()
             .stream()
-            .map(Locale::getLanguage)
+            .map(locale -> getLanguages(locale))
             .collect(Collectors.toSet());
         this.langParameterEnabled = langParameterEnabled;
     }
@@ -57,10 +68,20 @@ public class UrlLocaleResolver implements LocaleResolver {
             return null;
         }
 
+        lang = lang.replace("-", "_");
+
         if (!supportedLanguages.contains(lang.toLowerCase())) {
             return null;
         }
 
         return lang;
+    }
+
+    private String getLanguages(Locale locale) {
+        String localeCountry = locale.getCountry().toLowerCase();
+        if (fiveCharacterLanguages.containsKey(localeCountry)) {
+            return fiveCharacterLanguages.get(localeCountry).toLowerCase();
+        }
+        return locale.getLanguage();
     }
 }

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -2,10 +2,7 @@ package com.transferwise.urllocale;
 
 import static com.transferwise.urllocale.UrlLocaleExtractorFilter.URL_LOCALE_ATTRIBUTE;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -23,7 +23,7 @@ public class UrlLocaleResolver implements LocaleResolver {
 
     static {
         fiveCharacterLanguages  = new HashMap<>();
-        fiveCharacterLanguages.put("hk", "zh_HK");
+        fiveCharacterLanguages.put("hk", "zh_hk");
     }
 
     public UrlLocaleResolver(Map<String, Locale> urlLocaleToLocaleMapping, Locale fallback, boolean langParameterEnabled) {
@@ -43,12 +43,19 @@ public class UrlLocaleResolver implements LocaleResolver {
 
         String lang = resolveLangParameter(request);
         if (lang != null) {
-            locale = new Locale(lang, locale.getCountry());
+            locale = getLocaleFromLangParam(lang, locale);
         }
 
         return locale;
     }
 
+    private Locale getLocaleFromLangParam(String lang, Locale locale) {
+        if (fiveCharacterLanguages.containsValue(lang.toLowerCase())) {
+            return new Locale(lang.substring(0, 2), lang.substring(3));
+        } else {
+            return new Locale(lang, locale.getCountry());
+        }
+    }
     @Override
     public void setLocale(HttpServletRequest request, HttpServletResponse response, Locale locale) {
         throw new UnsupportedOperationException();

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
@@ -83,10 +83,10 @@ class UrlLocaleResolverTest {
         assertThat(actualLanguage).isEqualTo(expectedLanguage);
     }
 
-    @ParameterizedTest(name = "It should resolve lang parameter [{1}] for url locale /{0}/ to [{1}]")
+    @ParameterizedTest(name = "It should resolve lang parameter [{1}] for url locale /{0}/ to [{2}]")
     @CsvSource({
-            "de, zh-hk, zh_hk",
-            "de, zh_HK, zh_hk",
+            "de, zh-hk, zh-HK",
+            "de, zh_HK, zh-HK",
     })
     void itShouldResolveFiveCharacterLangParameters(String urlLocale, String langParam, String expectedLanguage) {
         Map<String, Locale> urlLocaleToLocaleMapping = new HashMap<>();
@@ -103,7 +103,7 @@ class UrlLocaleResolverTest {
         mockRequest.setAttribute(URL_LOCALE_ATTRIBUTE, urlLocale);
         mockRequest.setParameter("lang", langParam);
 
-        String actualLanguage = resolver.resolveLocale(mockRequest).getLanguage();
+        String actualLanguage = resolver.resolveLocale(mockRequest).toLanguageTag();
 
         assertThat(actualLanguage).isEqualTo(expectedLanguage);
     }

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
@@ -83,6 +83,31 @@ class UrlLocaleResolverTest {
         assertThat(actualLanguage).isEqualTo(expectedLanguage);
     }
 
+    @ParameterizedTest(name = "It should resolve lang parameter [{1}] for url locale /{0}/ to [{1}]")
+    @CsvSource({
+            "de, zh-hk, zh_hk",
+            "de, zh_HK, zh_hk",
+    })
+    void itShouldResolveFiveCharacterLangParameters(String urlLocale, String langParam, String expectedLanguage) {
+        Map<String, Locale> urlLocaleToLocaleMapping = new HashMap<>();
+        urlLocaleToLocaleMapping.put("de", new Locale("de", "DE"));
+        urlLocaleToLocaleMapping.put("es", new Locale("es", "ES"));
+        urlLocaleToLocaleMapping.put("zh-hk", new Locale("zh", "HK"));
+        UrlLocaleResolver resolver = new UrlLocaleResolver(
+                urlLocaleToLocaleMapping,
+                new Locale("en"),
+                true
+        );
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.setAttribute(URL_LOCALE_ATTRIBUTE, urlLocale);
+        mockRequest.setParameter("lang", langParam);
+
+        String actualLanguage = resolver.resolveLocale(mockRequest).getLanguage();
+
+        assertThat(actualLanguage).isEqualTo(expectedLanguage);
+    }
+
     @Test
     void itShouldIgnoreLangParameterWhenNotEnabled() {
         Map<String, Locale> urlLocaleToLocaleMapping = new HashMap<>();


### PR DESCRIPTION
## Context

Adds a map of 5 character locales (just zh-HK/zh_HK for now) and performs an extra check to be able to return it when querying with a lang param.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
