### PR TITLE
Added secure attribute to localedata cookie

### DIFF
--- a/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
@@ -37,6 +37,7 @@ public class LocaleDataCookieAddingInterceptor implements HandlerInterceptor {
             Cookie localeDataCookie = new Cookie(cookieName, language);
             localeDataCookie.setMaxAge(cookieMaxAge);
             localeDataCookie.setPath("/");
+            localeDataCookie.setSecure(true);
             response.addCookie(localeDataCookie);
         }
         return true;


### PR DESCRIPTION
## Context

Adds the `security` attribute to the `locateData` cookie, to hopefully make sure it sets properly.

If this doesn't work we would have to explicitly set the `same-site` attribute as well. Since Spring Security doesn't support the `same-site` attribute, we'd have to bump both spring and gradle to utilize the `ResponseCookie` to be able to pass a `set-cookie` header.

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
