### PR TITLE
[OGE-1329] Add api/ to filter's regex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group = 'com.github.transferwise'
-    version = '8.3.4'
+    version = '8.4.0'
 }
 
 subprojects {

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
@@ -20,7 +20,7 @@ public class UrlLocaleExtractorFilter implements Filter {
     @Deprecated // Prefer URL_LOCALE_ATTRIBUTE. Not removing as likely to be used in templates that may not be caught in dev.
     static final String LEGACY_LOCALE_ATTRIBUTE = "locale";
     public static final String URL_LOCALE_ATTRIBUTE = "urlLocale";
-    private static final Pattern PATH_PATTERN = Pattern.compile("^/([a-z]{2}(-[a-z]{2})?)/.*$");
+    private static final Pattern PATH_PATTERN = Pattern.compile("^/(api/)?([a-z]{2}(-[a-z]{2})?)/.*$");
 
     private Set<String> supportedUrlLocales;
 
@@ -42,12 +42,11 @@ public class UrlLocaleExtractorFilter implements Filter {
 
         Matcher matcher = PATH_PATTERN.matcher(req.getServletPath());
         if (matcher.matches()) {
-            String urlLocale = matcher.group(1);
+            String urlLocale = matcher.group(2);
             if (!supportedUrlLocales.contains(urlLocale)) {
                 ((HttpServletResponse) response).sendError(SC_NOT_FOUND);
                 return;
             }
-
             request.setAttribute(URL_LOCALE_ATTRIBUTE, urlLocale);
             request.setAttribute(LEGACY_LOCALE_ATTRIBUTE, urlLocale);
         }

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleExtractorFilterTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleExtractorFilterTest.java
@@ -42,11 +42,14 @@ class UrlLocaleExtractorFilterTest {
         "/gb/, gb",
         "/zh-hk/, zh-hk",
         "/es/some/path, es",
+        "/api/gb/someApiPath, gb",
+        "/api/ar/someApiPath, ar"
     })
     void itShouldSetRequestUrlLocaleAttribute(String path, String expectedUrlLocale) {
         whenUrlLocaleMappingConfigured("gb");
         whenUrlLocaleMappingConfigured("es");
         whenUrlLocaleMappingConfigured("zh-hk");
+        whenUrlLocaleMappingConfigured("ar");
 
         whenPathIs(path);
 


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
Adding `api/` to the urlLocale filter's regex makes sure we satisfy filter conditions when hitting `.../api/urlLocale/currency-converter/` and should prevent any issues when migrating our other apps in a similar way to how we are migrating currency-converter.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
