### PR TITLE
OGE-2678: Major version upgrade to Spring Boot 3 & related updates

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -26,10 +26,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
 
       - name: Retrieve cache
@@ -66,10 +66,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
 
       - name: Retrieve cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## [8.4.3] - Date not known
+
+## Init
+
+- It works for Spring Boot 2
+- It has javax dependencies
+- It's on Java 8
+
+## [9.0.1] - 2023-08-21
+
+### Changed
+- Updated to Java 17
+- Updated to Spring boot version 3.0.1
+- Replaced javax with jakarta

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,11 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'idea'
 
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     repositories {
         maven { url 'https://jitpack.io' }
@@ -36,20 +35,6 @@ subprojects {
         publications {
             mavenJava(MavenPublication) {
                 from components.java
-            }
-        }
-    }
-
-    install {
-        repositories.mavenInstaller {
-            pom.project {
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution 'repo'
-                    }
-                }
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version_number=8.4.3
+version_number=9.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/url-locale-core/build.gradle
+++ b/url-locale-core/build.gradle
@@ -1,19 +1,21 @@
 ext {
     junitVersion = '5.2.0'
-    springVersion = '4.3.10.RELEASE'
+    springVersion = '6.0.9'
 }
 
 dependencies {
-    compile 'javax.servlet:javax.servlet-api:3.1.0'
-    compile "org.springframework:spring-webmvc:$springVersion"
+    compileOnly 'jakarta.platform:jakarta.jakartaee-api:10.0.0'
+    compileOnly "org.springframework:spring-webmvc:$springVersion"
 
     testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation "org.springframework:spring-test:$springVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testImplementation 'org.mockito:mockito-core:2.+'
+    testImplementation 'jakarta.platform:jakarta.jakartaee-api:10.0.0'
+    testImplementation "org.springframework:spring-webmvc:$springVersion"
 
-    testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 }
 
 test {

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptor.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -66,5 +66,4 @@ public class LocaleDataCookieAddingInterceptor implements HandlerInterceptor {
         return request.getCookies() != null && Arrays.stream(request.getCookies())
             .anyMatch(cookie -> cookieName.equals(cookie.getName()));
     }
-
 }

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleExtractorFilter.java
@@ -1,19 +1,19 @@
 package com.transferwise.urllocale;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static javax.servlet.http.HttpServletResponse.*;
+import static jakarta.servlet.http.HttpServletResponse.*;
 
 public class UrlLocaleExtractorFilter implements Filter {
 

--- a/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
+++ b/url-locale-core/src/main/java/com/transferwise/urllocale/UrlLocaleResolver.java
@@ -7,8 +7,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.web.servlet.LocaleResolver;
 

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptorTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/LocaleDataCookieAddingInterceptorTest.java
@@ -8,10 +8,10 @@ import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.servlet.mvc.Controller;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleExtractorFilterTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleExtractorFilterTest.java
@@ -1,13 +1,13 @@
 package com.transferwise.urllocale;
 
+import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;

--- a/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
+++ b/url-locale-core/src/test/java/com/transferwise/urllocale/UrlLocaleResolverTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;

--- a/url-locale-starter/build.gradle
+++ b/url-locale-starter/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
-    compile project(':url-locale-core')
+    compileOnly project(':url-locale-core')
 
-    compile 'org.springframework.boot:spring-boot-autoconfigure:2.0.1.RELEASE'
+    compileOnly "org.springframework:spring-webmvc:6.0.9"
+
+    compileOnly 'org.springframework.boot:spring-boot-autoconfigure:3.1.0'
+    compileOnly 'jakarta.platform:jakarta.jakartaee-api:10.0.0'
 }

--- a/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
+++ b/url-locale-starter/src/main/java/com/transferwise/urllocale/UrlLocaleAutoConfiguration.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.LocaleResolver;
 
-import javax.servlet.Filter;
+import jakarta.servlet.Filter;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;


### PR DESCRIPTION
## Context

- Currently, we are upgrading our java services to Spring Boot 3
- As a part of the process, we are also doing major version upgrade in this library here as well.
- Spring Boot 3 only works with Java 17+, so we needed to upgrade it as well. Gradle also needed an update to match Java 17.
- Spring Boot 3 has some unexpected behavior with javax, and hence we are replacing it with jakarta (as recommended)>

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
