### PR TITLE
OGE-2678: JDK 17 to be used for Jitpack 

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk17
+before_install:
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open


### PR DESCRIPTION
## Context

- Our recent-most release `9.0.1` is failing on Jitpack because we had upgraded to Java 17 on that release.
- Jitpack by default uses java 8
- In this PR, we're configuring Jitpack build to use Java_17.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
