### PR TITLE
OGE-2678: Bumped version number for this repo after Jitpack Java config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version_number=9.0.1
+version_number=9.0.2


### PR DESCRIPTION
## Context

- Need to bump version number for the release
- Here's the previous PR: https://github.com/transferwise/url-locale/pull/53

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
